### PR TITLE
Add Spacer in correct place

### DIFF
--- a/UI/QuickMenu/IButtonPage.cs
+++ b/UI/QuickMenu/IButtonPage.cs
@@ -6,6 +6,7 @@ namespace ReMod.Core.UI.QuickMenu
     public interface IButtonPage
     {
         ReMenuButton AddButton(string text, string tooltip, Action onClick, Sprite sprite = null);
+        ReMenuButton AddSpacer(Sprite sprite = null);
         ReMenuToggle AddToggle(string text, string tooltip, Action<bool> onToggle, bool defaultValue = false);
         ReMenuToggle AddToggle(string text, string tooltip, ConfigValue<bool> configValue);
         ReMenuPage AddMenuPage(string text, string tooltip = "", Sprite sprite = null);

--- a/UI/QuickMenu/ReMenuCategory.cs
+++ b/UI/QuickMenu/ReMenuCategory.cs
@@ -178,6 +178,12 @@ namespace ReMod.Core.UI.QuickMenu
             return button;
         }
 
+        public ReMenuButton AddSpacer(Sprite sprite = null) {
+            var spacer = new ReMenuButton(string.Empty, string.Empty, null, _buttonContainer.RectTransform, sprite);
+            spacer.Background.gameObject.SetActive(false);
+            return spacer;
+        }
+
         public ReMenuToggle AddToggle(string text, string tooltip, Action<bool> onToggle, bool defaultValue = false)
         {
             var toggle = new ReMenuToggle(text, tooltip, onToggle, _buttonContainer.RectTransform, defaultValue);


### PR DESCRIPTION
Adding spacer button to ReMenuCategory
Example:
```cs
void Menu() {
    var cat = new ReMenuCategory("Category");
    cat.AddSpacer(); // <- I use spacers for/like this -- before the PR, it errored saying it didn't exist
}
```

The change to `IButtonPage.cs` _might_ not be necessary, but I added it just in case. (It could probably be ignored `¯\_(ツ)_/¯`)