### PR TITLE
Custom categories for ConfigValues

### DIFF
--- a/ConfigValue.cs
+++ b/ConfigValue.cs
@@ -22,6 +22,16 @@ namespace ReMod.Core
             _entry.OnValueChangedUntyped += () => OnValueChanged?.Invoke();
         }
 
+        public ConfigValue(string categoryName, string name, T defaultValue)
+        {
+            categoryName = categoryName == null ? ConfigManager.Instance.CategoryName : categoryName;
+            var category = MelonPreferences.CreateCategory(categoryName);
+
+            var entryName = string.Concat(name.Where(c => char.IsLetter(c) || char.IsNumber(c)));
+            _entry = category.GetEntry<T>(entryName) ?? category.CreateEntry(entryName, defaultValue);
+            _entry.OnValueChangedUntyped += () => OnValueChanged?.Invoke();
+        }
+
         public static implicit operator T(ConfigValue<T> conf)
         {
             return conf._entry.Value;

--- a/ConfigValue.cs
+++ b/ConfigValue.cs
@@ -24,7 +24,6 @@ namespace ReMod.Core
 
         public ConfigValue(string categoryName, string name, T defaultValue)
         {
-            categoryName = categoryName == null ? ConfigManager.Instance.CategoryName : categoryName;
             var category = MelonPreferences.CreateCategory(categoryName);
 
             var entryName = string.Concat(name.Where(c => char.IsLetter(c) || char.IsNumber(c)));


### PR DESCRIPTION
Using this example syntax:

`_TestConfigValue = new ConfigValue<bool>("ReModX", nameof(_TestConfigValue), false);`

Results with the following MelonPreferences entry:
```
[ReModX]
TestConfigValue = false
```
